### PR TITLE
Added distance to 'getNeighbors.'

### DIFF
--- a/lib/fixed-2d-array.js
+++ b/lib/fixed-2d-array.js
@@ -87,14 +87,20 @@ Fixed2DArray.prototype.set = function set(x, y, val) {
  *
  * @param x {number} x coordinate
  * @param y {number} y coordinate
+ * @param distance {number} length of the neighbor-square around the given coordinate.
  */
-Fixed2DArray.prototype.getNeighbours = function getNeighbours(x, y){
+Fixed2DArray.prototype.getNeighbours = function getNeighbours(x, y, distance){
   this.validateCoords(x,y);
+  
+  if(typeof distance === 'undefined'){ distance = 1; } 
+  if(distance<=0){
+    return [];
+  }
 
   var returnArray = [];
 
-  for(var i=x-1; i<=x+1; i++){
-    for(var j=y-1; j<=y+1; j++){
+  for(var i=x-distance; i<=x+distance; i++){
+    for(var j=y-distance; j<=y+distance; j++){
       try {
         if(!(i===x && j===y)) {
           var element = this.get(i,j);

--- a/test/test.js
+++ b/test/test.js
@@ -32,10 +32,14 @@ test('exception on index out of bounds', function (t) {
 });
 
 test('get correct number of neighbours',function (t) {
-  t.plan(3);
+  t.plan(7);
   var fa = new fixedArray(10,10);
   t.equal(fa.getNeighbours(5,5).length,8);
   t.equal(fa.getNeighbours(0,0).length,3);
   t.equal(fa.getNeighbours(1,0).length,5);
+  t.equal(fa.getNeighbours(0,0,2).length,8);
+  t.equal(fa.getNeighbours(2,2,2).length,24);
+  t.equal(fa.getNeighbours(2,2,0).length,0);
+  t.equal(fa.getNeighbours(2,2,-2).length,0);
 });
 


### PR DESCRIPTION
getNeighbors(2,2,2) will return an array of the contents of the neighbors from the point (2,2), but neighbors will be two squares away instead of one. I think of this as increasing the size of the
'neighbor-square.'

Examples:
distance = 1 (default)

```
 [ ][ ][ ][ ][ ]
 [ ][*][*][*][ ]
 [ ][*][X][*][ ]
 [ ][*][*][*][ ]
 [ ][ ][ ][ ][ ]
```

distance = 2

```
 [*][*][*][*][*]
 [*][*][*][*][*]
 [*][*][X][*][*]
 [*][*][*][*][*]
 [*][*][*][*][*]
```

distance = 0

```
 [ ][ ][ ][ ][ ]
 [ ][ ][ ][ ][ ]
 [ ][ ][X][ ][ ]
 [ ][ ][ ][ ][ ]
 [ ][ ][ ][ ][ ]
```

npm-test output:

```
  fixed-2d-array git:(master) npm test

> fixed-2d-array@1.0.2 test /Users/tbro/dev/fixed-2d-array
> node test/test.js

TAP version 13
# Default values
ok 1 should be equal
ok 2 should be equal
# getHeight and getWidth
ok 3 should be equal
ok 4 should be equal
# get and set
ok 5 should be equal
# exception on index out of bounds
ok 6 should throw
ok 7 should throw
ok 8 should throw
# get correct number of neighbours
ok 9 should be equal
ok 10 should be equal
ok 11 should be equal
ok 12 should be equal
ok 13 should be equal
ok 14 should be equal
ok 15 should be equal

1..15
# tests 15
# pass  15

# ok
```

coverage summary from running npm run test-coveralls:

```
npm run test-coveralls
-snip-
=============================== Coverage summary ===============================
Statements   : 100% ( 37/37 )
Branches     : 100% ( 14/14 )
Functions    : 100% ( 7/7 )
Lines        : 100% ( 36/36 )
================================================================================
-snip-
```
