### PR TITLE
New features, change to row/column from x/y coordinate

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,17 +8,17 @@
 
 > A fixed size 2D array in JavaScript
 
-This module gives you a two-dimensional array with a fixed size.
+This module gives you a two-dimensional array with a fixed size. The top left coordinate is (0,0).
 
-## Fixed2DArray(width, height, defaultValue)
-`width` is the width of the array and `height` is the height of the array. (That's kinda obvious, isn't it?)
-During the creation of the array the `defaultValue` will be asigned to all elements.
+## Fixed2DArray(rows, columns, defaultValue)
+`rows` is the number of rows the Fixed2DArray will start with, `columns` is the columns.
+During the creation of the array the `defaultValue` will be assigned to all elements.
 
-### validateCoords(x, y)
+### validateCoords(row, col)
 The `validateCoords` method checks if the given coordinates are valid. (lie inside of the array)
 If the coordinates are *not* valid an `Error` is thrown.
 
-### get(x, y)
+### get(row, col)
 Returns the value of the given coordinate. The coordinate is checked using `validateCoords`.
 
 ### getRow(rowIndex)
@@ -27,7 +27,7 @@ Returns an array of the requested row.
 ### getColumn(colIndex)
 Returns an array of the requested column.
 
-### set(x, y, value)
+### set(row, col, value)
 Sets the value of the given coordinate to `value`. The coordinate is checked using `validateCoords`.
 
 ### setRow(rowIndex, array)
@@ -37,12 +37,12 @@ Sets values of the given array as the values of the specified row.
 Sets values of the given array as the values of the specified column.
 
 ### getHeight()
-Returns the height of the array.
+The number of rows corresponds with the height.
 
 ### getWidth()
-Returns the width of the array.
+The number of columns corresponds to the width.
 
-### getNeighbours(x, y, [, distance])
+### getNeighbours(row, col, [, distance])
 Returns an array containing all values of the cells next to the given coordinate.
 
 For example, distance not set:
@@ -67,7 +67,7 @@ Example, distance = 2:
 
 The function will return an array containing the values for the fields marked with an '*'. Notice that distance will change what cells count as neighbors.
 
-### areNeighbours(x1, y1, x2, y2, [, distance])
+### areNeighbours(row1, col1, row2, col2, [, distance])
 Returns true if the given coordinates are neighbors, false otherwise.
 
 The distance between each coordinate must be within `distance` or one unit away from each other for the

--- a/README.md
+++ b/README.md
@@ -33,6 +33,15 @@ Sets the value of the given coordinate to `value`. The coordinate is checked usi
 ### setRow(rowIndex, array)
 Sets values of the given array as the values of the specified row.
 
+### pushRow([array1, array2, ..., arrayN])
+Adds one or more arrays as rows to the bottom of the Fixed2DArray.
+Returns the new width of the Fixed2DArray.
+
+Only arguments that are arrays will be appended as rows.
+
+If the given array is smaller then the height of the Fixed2DArray, `undefined` will fill
+the given array until it is the same length as the current row.
+
 ### setColumn(colIndex, array)
 Sets values of the given array as the values of the specified column.
 

--- a/README.md
+++ b/README.md
@@ -21,14 +21,20 @@ If the coordinates are *not* valid an `Error` is thrown.
 ### get(x, y)
 Returns the value of the given coordinate. The coordinate is checked using `validateCoords`.
 
-### getRow(rowNumber)
+### getRow(rowIndex)
 Returns an array of the requested row.
 
-### getColumn(colNumber)
+### getColumn(colIndex)
 Returns an array of the requested column.
 
 ### set(x, y, value)
 Sets the value of the given coordinate to `value`. The coordinate is checked using `validateCoords`.
+
+### setRow(rowIndex, array)
+Sets values of the given array as the values of the specified row.
+
+### setColumn(colIndex, array)
+Sets values of the given array as the values of the specified column.
 
 ### getHeight()
 Returns the height of the array.

--- a/lib/fixed-2d-array.js
+++ b/lib/fixed-2d-array.js
@@ -49,6 +49,35 @@ Fixed2DArray.prototype.getRow = function getRow(rowNumber) {
 };
 
 /**
+ * Sets the indicated row with the given array.
+ *
+ * If the given array is smaller then the current row, `undefined` will fill
+ * the given array until it is the same length as the current row.
+ *
+ * @param rowNumber {number} number of the row where top left is (0,0).
+ * @param newRow {array} array of values to replace the indicated row's values.
+ */
+Fixed2DArray.prototype.setRow = function setRow(rowNumber, newRow) {
+  try {
+    this.validateCoords(0, rowNumber);
+  } catch (err) {
+    throw new Error('fixed-2d-array: row number ' + rowNumber + ' is not valid.' +
+      ' The size of this array is (' + this._width + '/' + this._height + ')');
+  }
+
+  var currentRow = this.getRow(rowNumber);
+
+  if (newRow.length > currentRow.length){
+    throw new Error('fixed-2d-array: the length of the new row, '+newRow.length+
+      ', can not exceed the length of the current row, '+currentRow.length);
+  }
+
+  currentRow.forEach(function(_,index){
+    currentRow[index] = newRow[index];
+  });
+};
+
+/**
  * Returns the requested column from the grid.
  *
  * @param colNumber {number} number of the column where top left is (0,0).
@@ -67,6 +96,35 @@ Fixed2DArray.prototype.getColumn = function getColumn(colNumber) {
     returnArray.push(this._grid[i][colNumber]);
   }
   return returnArray;
+};
+
+/**
+ * Sets the indicated column with the given array.
+ *
+ * If the given array is smaller then the current column, `undefined` will fill
+ * the given array until it is the same length as the current column.
+ *
+ * @param colIndex {number} index of the column where top left is (0,0).
+ * @param newColumn {array} array of values to replace the indicated column's values.
+ */
+Fixed2DArray.prototype.setColumn = function setColumn(colIndex, newColumn) {
+  try {
+    this.validateCoords(colIndex, 0);
+  } catch (err) {
+    throw new Error('fixed-2d-array: column index ' + colIndex + ' is not valid.' +
+      ' The size of this array is (' + this._width + '/' + this._height + ')');
+  }
+
+  var currentColumn = this.getColumn(colIndex);
+
+  if (newColumn.length > currentColumn.length){
+    throw new Error('fixed-2d-array: the length of the new column, '+newColumn.length+
+      ', can not exceed the length of the current column, '+currentColumn.length);
+  }
+
+  for (var i = 0; i < currentColumn.length; i++){
+    this._grid[i][colIndex] = newColumn[i];
+  }
 };
 
 /**

--- a/lib/fixed-2d-array.js
+++ b/lib/fixed-2d-array.js
@@ -105,6 +105,22 @@ Fixed2DArray.prototype.validateCoords = function validateCoords(x, y) {
 };
 
 /**
+ * Returns true if the given object has the same height and width as the Fixed2DArray.
+ * Returns false if the given object does not have the same height and width as the Fixed2DArray.
+ * Throws an error if the given object does not have .getWidth() and .getHeight() methods.
+ *
+ * @param fixedArray {object with .getWidth() and .getHeight() methods} object to compare size with 
+ */
+Fixed2DArray.prototype.sameSize = function sameSize(fixedArray){
+  try{
+    return ((fixedArray.getWidth() === this.getWidth()) && (fixedArray.getHeight() === this.getHeight()));
+  }catch(err){
+    throw new Error('fixed-2d-array: the given object needs to implement a getWidth or getHeight method ' +
+                    'in order for Fixed2DArray to compare size.');
+  }
+};
+
+/**
  * Returns the value for the coordinate.
  *
  * @param x {number} x coordinate

--- a/lib/fixed-2d-array.js
+++ b/lib/fixed-2d-array.js
@@ -35,17 +35,17 @@ Fixed2DArray.prototype.getWidth = function getWidth() {
 /**
  * Returns the requested row from the grid.
  *
- * @param rowNumber {number} number of the row where top left is (0,0).
+ * @param rowIndex {number} index of the row where top left is (0,0).
  */
-Fixed2DArray.prototype.getRow = function getRow(rowNumber) {
+Fixed2DArray.prototype.getRow = function getRow(rowIndex) {
   try {
-    this.validateCoords(0, rowNumber);
+    this.validateCoords(0, rowIndex);
   } catch (err) {
-    throw new Error('fixed-2d-array: row number ' + rowNumber + ' is not valid.' +
+    throw new Error('fixed-2d-array: row index ' + rowIndex + ' is not valid.' +
       ' The size of this array is (' + this._width + '/' + this._height + ')');
   }
 
-  return this._grid[rowNumber];
+  return this._grid[rowIndex];
 };
 
 /**
@@ -54,18 +54,18 @@ Fixed2DArray.prototype.getRow = function getRow(rowNumber) {
  * If the given array is smaller then the current row, `undefined` will fill
  * the given array until it is the same length as the current row.
  *
- * @param rowNumber {number} number of the row where top left is (0,0).
+ * @param rowIndex {number} index of the row where top left is (0,0).
  * @param newRow {array} array of values to replace the indicated row's values.
  */
-Fixed2DArray.prototype.setRow = function setRow(rowNumber, newRow) {
+Fixed2DArray.prototype.setRow = function setRow(rowIndex, newRow) {
   try {
-    this.validateCoords(0, rowNumber);
+    this.validateCoords(0, rowIndex);
   } catch (err) {
-    throw new Error('fixed-2d-array: row number ' + rowNumber + ' is not valid.' +
+    throw new Error('fixed-2d-array: row index ' + rowIndex + ' is not valid.' +
       ' The size of this array is (' + this._width + '/' + this._height + ')');
   }
 
-  var currentRow = this.getRow(rowNumber);
+  var currentRow = this.getRow(rowIndex);
 
   if (newRow.length > currentRow.length){
     throw new Error('fixed-2d-array: the length of the new row, '+newRow.length+
@@ -80,20 +80,20 @@ Fixed2DArray.prototype.setRow = function setRow(rowNumber, newRow) {
 /**
  * Returns the requested column from the grid.
  *
- * @param colNumber {number} number of the column where top left is (0,0).
+ * @param colIndex {number} index of the column where top left is (0,0).
  */
-Fixed2DArray.prototype.getColumn = function getColumn(colNumber) {
+Fixed2DArray.prototype.getColumn = function getColumn(colIndex) {
   try {
-    this.validateCoords(colNumber, 0);
+    this.validateCoords(colIndex, 0);
   } catch (err) {
-    throw new Error('fixed-2d-array: column number ' + colNumber + ' is not valid.' +
+    throw new Error('fixed-2d-array: column index ' + colIndex + ' is not valid.' +
       ' The size of this array is (' + this._width + '/' + this._height + ')');
   }
 
   var returnArray = [];
 
   for (var i = 0; i < this._height; i++) {
-    returnArray.push(this._grid[i][colNumber]);
+    returnArray.push(this._grid[i][colIndex]);
   }
   return returnArray;
 };

--- a/lib/fixed-2d-array.js
+++ b/lib/fixed-2d-array.js
@@ -35,7 +35,7 @@ Fixed2DArray.prototype.getWidth = function getWidth() {
 /**
  * Returns the requested row from the grid.
  *
- * @param rowIndex {number} index of the row where top left is (0,0).
+ * @param rowIndex {number} index of the requested row.
  */
 Fixed2DArray.prototype.getRow = function getRow(rowIndex) {
   try {
@@ -80,7 +80,7 @@ Fixed2DArray.prototype.setRow = function setRow(rowIndex, newRow) {
 /**
  * Returns the requested column from the grid.
  *
- * @param colIndex {number} index of the column where top left is (0,0).
+ * @param colIndex {number} index of the requested column
  */
 Fixed2DArray.prototype.getColumn = function getColumn(colIndex) {
   try {
@@ -92,7 +92,7 @@ Fixed2DArray.prototype.getColumn = function getColumn(colIndex) {
 
   var returnArray = [];
 
-  for (var i = 0; i < this._height; i++) {
+  for (var i = 0; i < this._width; i++) {
     returnArray.push(this._grid[i][colIndex]);
   }
   return returnArray;

--- a/lib/fixed-2d-array.js
+++ b/lib/fixed-2d-array.js
@@ -1,18 +1,23 @@
 /**
  * An array with a fixed height and width.
  *
- * @param width {number} width of the array
- * @param height {number} height of the array
+ * @param row {number} number of rows, corresponds to the height.
+ * @param cols {number} number of columns, corresponds to the width.
  * @param defaultValue the initial value for the array elements
  * @class
  */
-var Fixed2DArray = function Fixed2DArray(width, height, defaultValue) {
-  this._width = width;
-  this._height = height;
+var Fixed2DArray = function Fixed2DArray(rows, cols, defaultValue) {
+  if(rows <= 0 || cols <= 0){
+    throw new Error('fixed-2d-array: Must have more then 0 rows and 0 columns.');
+  }
+
+  this._width = cols;
+  this._height = rows;
   this._grid = [];
-  for (var i = 0; i < width; i++) {
+
+  for (var i = 0; i < rows; i++) {
     this._grid[i] = [];
-    for (var j = 0; j < height; j++) {
+    for (var j = 0; j < cols; j++) {
       this._grid[i][j] = defaultValue;
     }
   }
@@ -39,7 +44,7 @@ Fixed2DArray.prototype.getWidth = function getWidth() {
  */
 Fixed2DArray.prototype.getRow = function getRow(rowIndex) {
   try {
-    this.validateCoords(0, rowIndex);
+    this.validateCoords(rowIndex,0);
   } catch (err) {
     throw new Error('fixed-2d-array: row index ' + rowIndex + ' is not valid.' +
       ' The size of this array is (' + this._width + '/' + this._height + ')');
@@ -62,7 +67,7 @@ Fixed2DArray.prototype.setRow = function setRow(rowIndex, newRow) {
     this.validateCoords(0, rowIndex);
   } catch (err) {
     throw new Error('fixed-2d-array: row index ' + rowIndex + ' is not valid.' +
-      ' The size of this array is (' + this._width + '/' + this._height + ')');
+      ' The size of this array is (' + this.getHeight() + '/' + this.getRow() + ')');
   }
 
   var currentRow = this.getRow(rowIndex);
@@ -84,15 +89,15 @@ Fixed2DArray.prototype.setRow = function setRow(rowIndex, newRow) {
  */
 Fixed2DArray.prototype.getColumn = function getColumn(colIndex) {
   try {
-    this.validateCoords(colIndex, 0);
+    this.validateCoords(0, colIndex);
   } catch (err) {
     throw new Error('fixed-2d-array: column index ' + colIndex + ' is not valid.' +
-      ' The size of this array is (' + this._width + '/' + this._height + ')');
+      ' The size of this array is (' + this.getHeight() + '/' + this.getWidth() + ')');
   }
 
   var returnArray = [];
 
-  for (var i = 0; i < this._width; i++) {
+  for (var i = 0; i < this._height; i++) {
     returnArray.push(this._grid[i][colIndex]);
   }
   return returnArray;
@@ -112,7 +117,7 @@ Fixed2DArray.prototype.setColumn = function setColumn(colIndex, newColumn) {
     this.validateCoords(colIndex, 0);
   } catch (err) {
     throw new Error('fixed-2d-array: column index ' + colIndex + ' is not valid.' +
-      ' The size of this array is (' + this._width + '/' + this._height + ')');
+      ' The size of this array is (' + this.getHeight() + '/' + this.getWid() + ')');
   }
 
   var currentColumn = this.getColumn(colIndex);
@@ -142,8 +147,8 @@ Fixed2DArray.prototype.setColumn = function setColumn(colIndex, newColumn) {
  * @param thisArg Optional. Value to use as this when executing callback.
  */
 Fixed2DArray.prototype.forEach = function forEach(fn, thisArg) {
-  for (var i = 0; i < this._width; i++) {
-    for (var j = 0; j < this._height; j++) {
+  for (var i = 0; i < this.getHeight(); i++) {
+    for (var j = 0; j < this.getWidth(); j++) {
       fn.call(thisArg, this._grid[i][j], { x: i, y: j }, this);
     }
   }
@@ -152,13 +157,13 @@ Fixed2DArray.prototype.forEach = function forEach(fn, thisArg) {
 /**
  * Throws an Error if the given coordinate is invalid.
  *
- * @param x {number} x coordinate
- * @param y {number} y coordinate
+ * @param row {number} index of the requested row
+ * @param col {number} index of the requested column
  */
-Fixed2DArray.prototype.validateCoords = function validateCoords(x, y) {
-  if (x < 0 || y < 0 || x >= this._width || y >= this._height) {
-    throw new Error('fixed-2d-array: the coordinate (' + x + '/' + y + ') ' +
-      'is not valid. The size of this array is (' + this._width + '/' + this._height + ')');
+Fixed2DArray.prototype.validateCoords = function validateCoords(row, col) {
+  if (row < 0 || col < 0 || row >= this.getHeight() || col >= this.getWidth()) {
+    throw new Error('fixed-2d-array: the coordinate (' + row + '/' + col + ') ' +
+      'is not valid. The size of this array is (' + this.getHeight() + '/' + this.getWidth() + ')');
   }
 };
 
@@ -173,7 +178,7 @@ Fixed2DArray.prototype.sameSize = function sameSize(fixedArray){
   try{
     return ((fixedArray.getWidth() === this.getWidth()) && (fixedArray.getHeight() === this.getHeight()));
   }catch(err){
-    throw new Error('fixed-2d-array: the given object needs to implement a getWidth or getHeight method ' +
+    throw new Error('fixed-2d-array: the given object needs to implement a getWidth and getHeight method ' +
                     'in order for Fixed2DArray to compare size.');
   }
 };
@@ -181,24 +186,24 @@ Fixed2DArray.prototype.sameSize = function sameSize(fixedArray){
 /**
  * Returns the value for the coordinate.
  *
- * @param x {number} x coordinate
- * @param y {number} y coordinate
+ * @param row {number} index of the requested row
+ * @param col {number} index of the requested column
  */
-Fixed2DArray.prototype.get = function get(x, y) {
-  this.validateCoords(x, y);
-  return this._grid[x][y];
+Fixed2DArray.prototype.get = function get(row, col) {
+  this.validateCoords(row, col);
+  return this._grid[row][col];
 };
 
 /**
  * Sets the value for the coordinate.
  *
- * @param x {number} x coordinate
- * @param y {number} y coordinate
+ * @param row {number} index of the requested row
+ * @param col {number} index of the requested column
  * @param val new value
  */
-Fixed2DArray.prototype.set = function set(x, y, val) {
-  this.validateCoords(x, y);
-  this._grid[x][y] = val;
+Fixed2DArray.prototype.set = function set(row, col, val) {
+  this.validateCoords(row, col);
+  this._grid[row][col] = val;
 };
 
 /**
@@ -215,14 +220,14 @@ Fixed2DArray.prototype.set = function set(x, y, val) {
  *
  * The given coordinate is marked with an `X`.
  * The function will return an array containing
- * the values for the fields maked with an `*`.
+ * the values for the fields marked with an `*`.
  *
- * @param x {number} x coordinate
- * @param y {number} y coordinate
+ * @param row {number} index of the requested row
+ * @param col {number} index of the requested column
  * @param distance {number} length of the neighbor-square around the given coordinate.
  */
-Fixed2DArray.prototype.getNeighbours = function getNeighbours(x, y, distance) {
-  this.validateCoords(x, y);
+Fixed2DArray.prototype.getNeighbours = function getNeighbours(row, col, distance) {
+  this.validateCoords(row, col);
 
   if (typeof distance === 'undefined') { distance = 1; }
   if (distance <= 0) {
@@ -231,10 +236,10 @@ Fixed2DArray.prototype.getNeighbours = function getNeighbours(x, y, distance) {
 
   var returnArray = [];
 
-  for (var i = x - distance; i <= x + distance; i++) {
-    for (var j = y - distance; j <= y + distance; j++) {
+  for (var i = row - distance; i <= row + distance; i++) {
+    for (var j = col - distance; j <= col + distance; j++) {
       try {
-        if (!(i === x && j === y)) {
+        if (!(i === row && j === col)) {
           var element = this.get(i, j);
           returnArray.push(element);
         }
@@ -284,15 +289,15 @@ Fixed2DArray.prototype.getNeighbours = function getNeighbours(x, y, distance) {
  *
  * A (0,0) and B (2,2) are neighbors.
  * 
- * @param x1 {number} first x coordinate.
- * @param y1 {number} first y coordinate.
- * @param x2 {number} second x coordinate.
- * @param y2 {number} second y coordinate.
+ * @param row1 {number} first row index.
+ * @param col1 {number} first column index.
+ * @param row2 {number} second row index.
+ * @param col2 {number} second column index.
  * @param distance {number} Optional. Maximum distance for coordinates to be considered neighbors.
  */
-Fixed2DArray.prototype.areNeighbours = function areNeighbours(x1, y1, x2, y2, distance) {
-  this.validateCoords(x1, y1);
-  this.validateCoords(x2, y2);
+Fixed2DArray.prototype.areNeighbours = function areNeighbours(row1, col1, row2, col2, distance) {
+  this.validateCoords(row1, col1);
+  this.validateCoords(row2, col2);
 
   if (typeof distance === 'undefined') { distance = 1; }
   if (distance <= 0) {
@@ -300,7 +305,7 @@ Fixed2DArray.prototype.areNeighbours = function areNeighbours(x1, y1, x2, y2, di
   }
 
 
-  return (Math.abs(x1 - x2) <= distance) && (Math.abs(y1 - y2) <= distance);
+  return (Math.abs(row1 - row2) <= distance) && (Math.abs(col1 - col2) <= distance);
 };
 
 module.exports = Fixed2DArray;

--- a/lib/fixed-2d-array.js
+++ b/lib/fixed-2d-array.js
@@ -83,6 +83,35 @@ Fixed2DArray.prototype.setRow = function setRow(rowIndex, newRow) {
 };
 
 /**
+ * Adds one or more arrays to the bottom of the Fixed2DArray.
+ * Returns the new width of the Fixed2DArray.
+ *
+ * Only arguments that are arrays will be appended as rows.
+ *
+ * If the given array is smaller then the height of the Fixed2DArray, `undefined` will fill
+ * the given array until it is the same length as the current row.
+ */
+Fixed2DArray.prototype.pushRow = function pushRow() {
+  for (var i = 0; i < arguments.length; i++){
+    var newRow = arguments[i];
+
+    if(newRow.constructor !== Array){ continue; }
+    else if (newRow.length > this.getWidth()){ //no adding rows that are too wide.
+      throw new Error('fixed-2d-array: the length of the new row, '+newRow.length+
+        ', can not exceed the length of the current rows, '+this.getWidth());
+    }
+    else{ //expand a smaller row to be the same size as other rows.
+      for (var j = newRow.length; j < this.getWidth(); j++){
+        newRow[j] = undefined;
+      }
+    }
+    this._grid[this.getHeight()] = newRow;
+    this._height += 1;
+  }
+  return this.getHeight();
+};
+
+/**
  * Returns the requested column from the grid.
  *
  * @param colIndex {number} index of the requested column

--- a/test/test.js
+++ b/test/test.js
@@ -25,10 +25,10 @@ test('get and set', function (t) {
 
 test('get correct row and column',function (t) {
   t.plan(6);
-  var fa = new fixedArray(10,10);
+  var fa = new fixedArray(2,3);
 
-  t.equal(fa.getRow(0).length,10);
-  t.equal(fa.getColumn(1).length,10);
+  t.equal(fa.getRow(0).length,3);
+  t.equal(fa.getColumn(1).length,2);
 
   fa.set(0,1,'This is a string!');
   t.equal(fa.getRow(0)[1],'This is a string!');

--- a/test/test.js
+++ b/test/test.js
@@ -2,25 +2,28 @@ var test = require('tape');
 var fixedArray = require('..');
 
 test('Default values', function (t) {
-  t.plan(2);
-  var fa = new fixedArray(10,10,{abc:123});
-  t.equal(fa.get(9,9).abc,123);
-  t.equal(fa.get(0,0).abc,123);
+  t.plan(3);
+  var fa = new fixedArray(8,9,{abc:123});
+  t.equal(fa.get(7,8).abc,123);
+  t.equal(fa.get(0,1).abc,123);
+  t.throws(function(){new fixedArray(0,1);});
 });
 
 test('getHeight and getWidth', function (t) {
   t.plan(2);
   var fa = new fixedArray(3,17);
 
-  t.equal(fa.getHeight(),17);
-  t.equal(fa.getWidth(),3);
+  t.equal(fa.getHeight(),3);
+  t.equal(fa.getWidth(),17);
 });
 
 test('get and set', function (t) {
-  t.plan(1);
-  var fa = new fixedArray(10,10);
-  fa.set(9,7,'This is a string!');
-  t.equal(fa.get(9,7),'This is a string!');
+  t.plan(3);
+  var fa = new fixedArray(2,3);
+  fa.set(1,2,'This is a string!');
+  t.equal(fa.get(1,2),'This is a string!');
+  t.throws(function(){fa.set(2,3);});
+  t.throws(function(){fa.get(9,9);});
 });
 
 test('get correct row and column',function (t) {
@@ -33,8 +36,8 @@ test('get correct row and column',function (t) {
   fa.set(0,1,'This is a string!');
   t.equal(fa.getRow(0)[1],'This is a string!');
   t.equal(fa.getColumn(1)[0],'This is a string!');
-  t.throws(function(){fa.getRow(-1);});
-  t.throws(function(){fa.getColumn(11);});
+  t.throws(function(){fa.getRow(2);});
+  t.throws(function(){fa.getColumn(3);});
 });
 
 test('set row and column',function (t) {
@@ -63,7 +66,7 @@ test('set row and column',function (t) {
 
 test('forEach',function (t) {
   t.plan(1);
-  var fa = new fixedArray(10,10,0);
+  var fa = new fixedArray(10,9,0);
 
   function fun(currentValue, index, array){
     array.set(index.x, index.y, currentValue+1);
@@ -74,11 +77,10 @@ test('forEach',function (t) {
 });
 
 test('exception on index out of bounds', function (t) {
-  t.plan(3);
-  var fa = new fixedArray(10,10);
-  t.throws(function(){fa.get(10,10);});
-  t.throws(function(){fa.get(-1,-1);});
-  t.throws(function(){fa.getNeighbours(-1,-1);});
+  t.plan(2);
+  var fa = new fixedArray(2,3);
+  t.throws(function(){fa.get(2,3);});
+  t.throws(function(){fa.set(-1,-1);});
 });
 
 test('sameSize',function (t) {
@@ -95,7 +97,7 @@ test('sameSize',function (t) {
 
 test('get correct number of neighbours',function (t) {
   t.plan(7);
-  var fa = new fixedArray(10,10);
+  var fa = new fixedArray(9,10);
   t.equal(fa.getNeighbours(5,5).length,8);
   t.equal(fa.getNeighbours(0,0).length,3);
   t.equal(fa.getNeighbours(1,0).length,5);

--- a/test/test.js
+++ b/test/test.js
@@ -57,6 +57,18 @@ test('exception on index out of bounds', function (t) {
   t.throws(function(){fa.getNeighbours(-1,-1);});
 });
 
+test('sameSize',function (t) {
+  t.plan(3);
+  var fa = new fixedArray(2,2);
+  var faSameSize = new fixedArray(2,2);
+  var faNotSameSize = new fixedArray(2,3);
+  var nonfa = [2,2,2,2];
+
+  t.true(fa.sameSize(faSameSize));
+  t.false(fa.sameSize(faNotSameSize));
+  t.throws(function(){fa.sameSize(nonfa);});
+});
+
 test('get correct number of neighbours',function (t) {
   t.plan(7);
   var fa = new fixedArray(10,10);
@@ -79,4 +91,3 @@ test('areNeighbors',function (t) {
   t.throws(function(){fa.areNeighbours(0,0,-1,1);});
   t.equal(fa.areNeighbours(0,0,1,1,0),false);
 });
-

--- a/test/test.js
+++ b/test/test.js
@@ -117,3 +117,12 @@ test('areNeighbors',function (t) {
   t.throws(function(){fa.areNeighbours(0,0,-1,1);});
   t.equal(fa.areNeighbours(0,0,1,1,0),false);
 });
+
+test('pushRow',function (t) {
+  t.plan(4);
+  var fa = new fixedArray(2,3);
+  t.equal(fa.pushRow([1,2,3],[1,2]),4);
+  t.equal(fa.get(3,2),undefined);
+  t.throws(function(){fa.pushRow([1,2,3,4]);});
+  t.equal(fa.pushRow(2),4);
+});

--- a/test/test.js
+++ b/test/test.js
@@ -37,6 +37,30 @@ test('get correct row and column',function (t) {
   t.throws(function(){fa.getColumn(11);});
 });
 
+test('set row and column',function (t) {
+  t.plan(8);
+  var fa = new fixedArray(5,5,0);
+  var newPillar = [1,2,3,4,5];
+
+  fa.setRow(0,newPillar);
+  t.deepEqual(fa.getRow(0),newPillar);
+  fa.setColumn(0,newPillar);
+  t.deepEqual(fa.getColumn(0),newPillar,console.log(fa._grid));
+
+  t.throws(function(){fa.setRow(-1,newPillar);});
+  t.throws(function(){fa.setColumn(-1,newPillar);});
+
+  var smallPillar = [1,2];
+  fa.setRow(0,smallPillar);
+  t.equal(fa.getRow(0)[3],undefined);
+  fa.setColumn(0,smallPillar);
+  t.equal(fa.getColumn(0)[3],undefined);
+
+  var largePillar = [1,2,3,4,5,6];
+  t.throws(function(){fa.setRow(0,largePillar);});
+  t.throws(function(){fa.setColumn(0,largePillar);});
+});
+
 test('forEach',function (t) {
   t.plan(1);
   var fa = new fixedArray(10,10,0);

--- a/test/test.js
+++ b/test/test.js
@@ -45,7 +45,7 @@ test('set row and column',function (t) {
   fa.setRow(0,newPillar);
   t.deepEqual(fa.getRow(0),newPillar);
   fa.setColumn(0,newPillar);
-  t.deepEqual(fa.getColumn(0),newPillar,console.log(fa._grid));
+  t.deepEqual(fa.getColumn(0),newPillar);
 
   t.throws(function(){fa.setRow(-1,newPillar);});
   t.throws(function(){fa.setColumn(-1,newPillar);});


### PR DESCRIPTION
In response to #7: 
Width and Height now correspond with Rows and Columns. …
- The more rows there are, the taller the height.
- The more columns there are, the longer the width.
- Instead of thinking in (x,y) coordinates, instead think in (row,col)
  where (0,0) is in the top left. This is how the code always worked, but
  speaking of (x,y) coordinates gets one thinking of a Cartesian graph
  where (0,0) is in the bottom left of Q1.
- Changes to tests to test rectangles instead of squares to catch edge
  cases.
- Changes in README to reflect this change.

Working towards #5, which will come after push/pop and shift/unshift row/col.
