### PR TITLE
patch: getNeighbours now correctly converts variable to numbers

### DIFF
--- a/lib/fixed-2d-array.js
+++ b/lib/fixed-2d-array.js
@@ -265,8 +265,8 @@ Fixed2DArray.prototype.getNeighbours = function getNeighbours(row, col, distance
 
   var returnArray = [];
 
-  for (var i = row - distance; i <= row + distance; i++) {
-    for (var j = col - distance; j <= col + distance; j++) {
+  for (var i = row - distance; i <= row + Number(distance); i++) {
+    for (var j = col - distance; j <= col + Number(distance); j++) {
       try {
         if (!(i === row && j === col)) {
           var element = this.get(i, j);

--- a/test/test.js
+++ b/test/test.js
@@ -96,13 +96,15 @@ test('sameSize',function (t) {
 });
 
 test('get correct number of neighbours',function (t) {
-  t.plan(7);
+  t.plan(8);
   var fa = new fixedArray(9,10);
+  var treatMeLikeANumber = 2;
   t.equal(fa.getNeighbours(5,5).length,8);
   t.equal(fa.getNeighbours(0,0).length,3);
   t.equal(fa.getNeighbours(1,0).length,5);
   t.equal(fa.getNeighbours(0,0,2).length,8);
   t.equal(fa.getNeighbours(2,2,2).length,24);
+  t.equal(fa.getNeighbours(treatMeLikeANumber,treatMeLikeANumber,treatMeLikeANumber).length,24);
   t.equal(fa.getNeighbours(2,2,0).length,0);
   t.equal(fa.getNeighbours(2,2,-2).length,0);
 });


### PR DESCRIPTION
as apposed to concating two strings.

You have no idea how long it took me to discover this bug :(.
npm run test

```
> fixed-2d-array@1.2.0 test /Users/tbro/dev/fixed-2d-array
> node test/test.js

TAP version 13
# Default values
ok 1 should be equal
ok 2 should be equal
ok 3 should throw
# getHeight and getWidth
ok 4 should be equal
ok 5 should be equal
# get and set
ok 6 should be equal
ok 7 should throw
ok 8 should throw
# get correct row and column
ok 9 should be equal
ok 10 should be equal
ok 11 should be equal
ok 12 should be equal
ok 13 should throw
ok 14 should throw
# set row and column
ok 15 should be equivalent
ok 16 should be equivalent
ok 17 should throw
ok 18 should throw
ok 19 should be equal
ok 20 should be equal
ok 21 should throw
ok 22 should throw
# forEach
ok 23 should be equal
# exception on index out of bounds
ok 24 should throw
ok 25 should throw
# sameSize
ok 26 (unnamed assert)
ok 27 (unnamed assert)
ok 28 should throw
# get correct number of neighbours
ok 29 should be equal
ok 30 should be equal
ok 31 should be equal
ok 32 should be equal
ok 33 should be equal
ok 34 should be equal
ok 35 should be equal
ok 36 should be equal
# areNeighbors
ok 37 (unnamed assert)
ok 38 (unnamed assert)
ok 39 (unnamed assert)
ok 40 should throw
ok 41 should throw
ok 42 should be equal
# pushRow
ok 43 should be equal
ok 44 should be equal
ok 45 should throw
ok 46 should be equal

1..46
# tests 46
# pass  46

# ok
```

npm run test-coveralls

```
=============================== Coverage summary ===============================
Statements   : 100% ( 98/98 )
Branches     : 100% ( 34/34 )
Functions    : 100% ( 16/16 )
Lines        : 100% ( 95/95 )
================================================================================
```

npm run jshint

```
> fixed-2d-array@1.2.0 jshint /Users/tbro/dev/fixed-2d-array
> jshint test/* lib/*
```
